### PR TITLE
Fix linalg.incidence_matrix() parameters bug

### DIFF
--- a/hypergraphx/core/hypergraph.py
+++ b/hypergraphx/core/hypergraph.py
@@ -954,11 +954,11 @@ class Hypergraph:
         return binary_incidence_matrix(self, return_mapping)
 
     def incidence_matrix(
-        self, shape: Optional[Tuple[int]] = None, return_mapping: bool = False
+        self, return_mapping: bool = False
     ):
         from hypergraphx.linalg import incidence_matrix
 
-        return incidence_matrix(self, shape, return_mapping)
+        return incidence_matrix(self, return_mapping)
 
     def adjacency_matrix(self, return_mapping: bool = False):
         from hypergraphx.linalg import adjacency_matrix


### PR DESCRIPTION
The library function `linalg.incidence_matrix()` accepts two arguments, but the interface for the same defines three arguments. Thus, calling the function causes errors. This commit fixes this bug.

**Steps to reproduce:**
1. Build a hypergraph (eg. `hg1`).
2. Call the incidence matrix via `hg1.incidence_matrix()`

**Expected Behavior:**
Should return the incidence matrix correctly.

**Bug:**
Error on step 2.