### PR TITLE
Fix get_edges() and linalg.incidence_matrix_by_order()

### DIFF
--- a/hypergraphx/core/hypergraph.py
+++ b/hypergraphx/core/hypergraph.py
@@ -871,23 +871,27 @@ class Hypergraph:
         if subhypergraph and keep_isolated_nodes:
             h = Hypergraph(weighted=self._weighted)
             h.add_nodes(self.get_nodes())
-            h.add_edges(edges)
+            if self._weighted:
+                edge_weights = [self.get_weight(edge) for edge in edges]
+                h.add_edges(edges, edge_weights)
+            else:
+                h.add_edges(edges)
+                
             for node in h.get_nodes():
                 h.set_meta(node, self.get_meta(node))
             for edge in h.get_edges():
                 h.set_meta(edge, self.get_meta(edge))
-            if self._weighted:
-                for edge in h.get_edges():
-                    h.set_weight(edge, self.get_weight(edge))
             return h
         elif subhypergraph:
             h = Hypergraph(weighted=self._weighted)
-            h.add_edges(edges)
+            if self._weighted:
+                edge_weights = [self.get_weight(edge) for edge in edges]
+                h.add_edges(edges, edge_weights)
+            else:
+                h.add_edges(edges)
+
             for edge in h.get_edges():
                 h.set_meta(edge, self.get_meta(edge))
-            if self._weighted:
-                for edge in h.get_edges():
-                    h.set_weight(edge, self.get_weight(edge))
             return h
         else:
             return edges
@@ -959,6 +963,13 @@ class Hypergraph:
         from hypergraphx.linalg import incidence_matrix
 
         return incidence_matrix(self, return_mapping)
+    
+    def incidence_matrix_by_order(
+            self, order: int, shape: Optional[Tuple[int]] = None, keep_isolated_nodes:bool=False, return_mapping: bool = False
+    ):
+        from hypergraphx.linalg import incidence_matrix_by_order
+
+        return incidence_matrix_by_order(self, order, shape, keep_isolated_nodes, return_mapping)
 
     def adjacency_matrix(self, return_mapping: bool = False):
         from hypergraphx.linalg import adjacency_matrix

--- a/hypergraphx/core/hypergraph.py
+++ b/hypergraphx/core/hypergraph.py
@@ -963,13 +963,6 @@ class Hypergraph:
         from hypergraphx.linalg import incidence_matrix
 
         return incidence_matrix(self, return_mapping)
-    
-    def incidence_matrix_by_order(
-            self, order: int, shape: Optional[Tuple[int]] = None, keep_isolated_nodes:bool=False, return_mapping: bool = False
-    ):
-        from hypergraphx.linalg import incidence_matrix_by_order
-
-        return incidence_matrix_by_order(self, order, shape, keep_isolated_nodes, return_mapping)
 
     def adjacency_matrix(self, return_mapping: bool = False):
         from hypergraphx.linalg import adjacency_matrix

--- a/hypergraphx/linalg/linalg.py
+++ b/hypergraphx/linalg/linalg.py
@@ -95,7 +95,7 @@ def incidence_matrix(
     hypergraph: Hypergraph,
     return_mapping: bool = False,
 ) -> sparse.csr_array | Tuple[sparse.csr_array, Dict[int, Any]]:
-    """Produce the binary incidence matrix representing a hypergraph.
+    """Produce the incidence matrix representing a hypergraph.
     For any node i and hyperedge e, the entry (i, e) of the binary incidence matrix is
     the weight of the hyperedge if the node belongs to it, 0 otherwise.
 
@@ -148,10 +148,12 @@ def incidence_matrix_by_order(
     If return_mapping is True, return the dictionary of node mappings.
     """
     binary_incidence, mapping = binary_incidence_matrix(
-        hypergraph.get_edges(order=order, subhypergraph=True, keep_isolated_nodes=keep_isolated_nodes), return_mapping
+        hypergraph.get_edges(order=order, subhypergraph=True, keep_isolated_nodes=keep_isolated_nodes), return_mapping=True
     )
     incidence = binary_incidence.multiply(hypergraph.get_weights(order=order)).tocsr()
-    return incidence, mapping
+    if return_mapping:
+        return incidence, mapping
+    return incidence
 
 
 def incidence_matrices_all_orders(


### PR DESCRIPTION

1. Exposed incidence_matrix_by_order() to be called directly from an object (eg. `hg1.incidence_matrix_by_order(2)` is now possible.)
2. `get_edges()` had a bug where, while initializing a subhypergraph from a weighted hypergraph the weights were not being provided correctly. This commit fixes said issue.
3. Fix minor parameter bug in the function `linalg.incidence_matrix_by_order()`

Please check and let me know if any edge cases are breaking. That can also help when writing tests for this module, which is my eventual plan. Thanks!