### PR TITLE
Fix `draw_hypergraph` color error

### DIFF
--- a/hypergraphx/viz/draw_hypergraph.py
+++ b/hypergraphx/viz/draw_hypergraph.py
@@ -3,6 +3,7 @@ from typing import Optional, Union
 import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
+import random
 
 from hypergraphx import Hypergraph
 from hypergraphx.representations.projections import clique_projection
@@ -176,8 +177,15 @@ def draw_hypergraph(
             y1 = [j for i, j in Smoothed_obj]
 
             order = len(hye) - 1
+
             if order not in hyperedge_color_by_order.keys():
-                hyperedge_color_by_order[order] = "Black"
+                std_color = "#" + "%06x" % random.randint(0, 0xFFFFFF)
+                hyperedge_color_by_order[order] = std_color
+            
+            if order not in hyperedge_facecolor_by_order.keys():
+                std_face_color = "#" + "%06x" % random.randint(0, 0xFFFFFF)
+                hyperedge_facecolor_by_order[order] = std_face_color
+
             color = hyperedge_color_by_order[order]
             facecolor = hyperedge_facecolor_by_order[order]
             plt.fill(


### PR DESCRIPTION
`viz.draw_hypergraph()` had the following error because the color map did not exist for all orders. I have added a fix for this error by generating random colors for each such order.
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[5], line 1
----> 1 viz.draw_hypergraph(hg1)

File [~/research/hypergraphx/hypergraphx/viz/draw_hypergraph.py:182](https://file+.vscode-resource.vscode-cdn.net/home/bisco/research/hypergraphx/~/research/hypergraphx/hypergraphx/viz/draw_hypergraph.py:182), in draw_hypergraph(hypergraph, figsize, ax, pos, edge_color, hyperedge_color_by_order, hyperedge_facecolor_by_order, edge_width, hyperedge_alpha, node_size, node_color, node_facecolor, node_shape, with_node_labels, label_size, label_col, seed, scale, iterations, opt_dist)
    180             hyperedge_color_by_order[order] = "Black"
    181         color = hyperedge_color_by_order[order]
--> 182         facecolor = hyperedge_facecolor_by_order[order]
    183         plt.fill(
    184             x1, y1, alpha=hyperedge_alpha, c=color, edgecolor=facecolor
    185         )
    187 nx.draw_networkx_edges(G, pos, width=edge_width, edge_color=edge_color, ax=ax)

KeyError: 6
```