### PR TITLE
Fix typo in README regarding third-party sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ Released under the 3-Clause BSD license. See [LICENSE.md](LICENSE.md).
 
 This project is supported by the Air Force Office of Scientific Research under award number FA8655-22-1-7025.
 
-HGX contains copied or modified code from third sources. The licenses of such code sources can be found in [LICENSE.md](LICENSE.md).
+HGX contains copied or modified code from third-party sources. The licenses of such code sources can be found in [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
## Summary
Fixes a wording error in the README's acknowledgments section. "third sources" was corrected to "third-party sources" for clarity and correctness.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor/maintenance

## Validation
- [x] `black --check .` (not applicable, no code changed)
- [x] `ruff check .` (not applicable, no code changed)
- [x] `pytest` (not applicable, no code changed)
- [x] `python -m build` (not applicable, no code changed)
- [x] `twine check dist/*` (not applicable, no code changed)

## Checklist
- [x] Added or updated tests for behavior changes (not applicable, no behavior change)
- [x] Updated docs for user-facing changes
- [x] Kept changes focused and scoped